### PR TITLE
Change the http handler from prometheus to promhttp

### DIFF
--- a/prometheus-zfs.go
+++ b/prometheus-zfs.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 const (
@@ -138,7 +139,7 @@ func main() {
 	prometheus.MustRegister(exporter)
 
 	fmt.Printf("Starting zpool metrics exporter on :%s/%s\n", listenPort, metricsHandle)
-	http.Handle("/"+metricsHandle, prometheus.Handler())
+	http.Handle("/"+metricsHandle, promhttp.Handler())
 	http.ListenAndServe(":"+listenPort, nil)
 
 }


### PR DESCRIPTION
Latest versions of prometheus fail to compile, as [line 141](https://github.com/mihalea/prometheus-zfs/blob/d6e7b3ad84cb41586f5da5585132c13faddd2581/prometheus-zfs.go#L141) throws an error. Prometheus documentation uses promhttp to get an http handler, and I assume the functionality has been moved from prometheus to promhttp.